### PR TITLE
Decrease limits from 1 every minute down to 1 every 5 seconds

### DIFF
--- a/secretupdater/secretupdater/views.py
+++ b/secretupdater/secretupdater/views.py
@@ -44,7 +44,7 @@ def internal_healthcheck():
 
 
 @app.route('/v1/update', methods=['POST'])
-@LIMITER.limit("1/minute", get_services_from_body)
+@LIMITER.limit("12/minute", get_services_from_body)
 @basic_auth.required
 def receive_webhook():
     '''


### PR DESCRIPTION
Multiple releases may trigger secrets changes more frequently that 1 per minute.