### PR TITLE
:pushpin: Update dependencies (Flask and ConfidantClient)

### DIFF
--- a/secretupdater/requirements.txt
+++ b/secretupdater/requirements.txt
@@ -1,5 +1,5 @@
-Flask==1.0.2
+Flask==2.0.3
 Flask-BasicAuth==0.2.0
-confidant-client==1.7.1
+confidant-client==2.1.0
 pykube-ng==20.10.0
 awscli==1.22.24


### PR DESCRIPTION
-  :pushpin: Flask 2.0.3

- -  Fixes an import issue `ImportError: cannot import name 'Markup' from 'jinja2' (/usr/local/lib/python3.7/site-packages/jinja2/__init__.py)`

-  :pushpin: confidant-client 2.1.0
- - Helps fix an issue with connection timeouts when Communicating with Confidant