### PR TITLE
:sparkles: Allow Request and liburl3 helper parameters to be set via envs

### DIFF
--- a/secretupdater/secretupdater/config.py
+++ b/secretupdater/secretupdater/config.py
@@ -72,3 +72,8 @@ class Config():
         'CONFIDANT_SERVER_AUTH_KEY', 'auth-key')
     CONFIDANT_SERVER_AWS_REGION = str_env(
         'CONFIDANT_SERVER_AWS_REGION', 'ap-southeast-2')
+
+    # Request / libURL3 Helper
+    REQUEST_BACKOFF = int_env('CONFIDANT_REQUEST_BACKOFF', 1)
+    REQUEST_TIMEOUT = int_env('CONFIDANT_REQUEST_TIMEOUT', 5)
+    REQUEST_RETRIES = int_env('CONFIDANT_REQUEST_RETRIES', 0)

--- a/secretupdater/secretupdater/models.py
+++ b/secretupdater/secretupdater/models.py
@@ -166,7 +166,10 @@ def _setup_confidant_client(service):
             "from": service
         },
         region=app.config.get('CONFIDANT_SERVER_AWS_REGION'),
-        token_cache_file='/tmp/confidant_token'
+        token_cache_file='/tmp/confidant_token',
+        backoff=app.config.get('CONFIDANT_REQUEST_BACKOFF'),
+        timeout=app.config.get('CONFIDANT_REQUEST_TIMEOUT'),
+        retries=app.config.get('CONFIDANT_REQUEST_RETRIES')
     )
     app.logger.debug(client.config)
     return client


### PR DESCRIPTION
Allow Request and liburl3 helper parameters to be set via environment values.

As per [ConfidantClient Object](https://github.com/lyft/python-confidant-client/blob/master/confidant_client/__init__.py#L71) we can set request and liburl parameters. This change will allow us to override these via environment values.