### PR TITLE
🐛 HeaderClient: no "config"

### DIFF
--- a/secretupdater/secretupdater/headerclient.py
+++ b/secretupdater/secretupdater/headerclient.py
@@ -21,6 +21,7 @@ class HeaderClient():
     def __init__(self, **_kwargs):
         super(HeaderClient, self).__init__()
         app.logger.debug("Initialising HeaderClient")
+        self.config = {}
 
     def get_service(self, service):
         app.logger.debug("DummyClient.get_service")


### PR DESCRIPTION
In debugging/development, we may use the "HeaderClient" instead of the real "ConfidantClient". Some strange behaviour here made my debugging journey more difficult, so lets fix that.

in `models.py:32`
```
   from secretupdater.headerclient import HeaderClient as ConfidantClient
```

`models.py:182`
```
    client = ConfidantClient(
      ...
    )
    app.logger.debug(client.config)
```

this fails because `client` (when its `HeaderClient`) doesnt have a `.config`. Lets just give it one.