### PR TITLE
Skip over bad k8s auth.

### DIFF
--- a/secretupdater/secretupdater/models.py
+++ b/secretupdater/secretupdater/models.py
@@ -77,7 +77,14 @@ def process(event):
             # Create a hashed value, to see if the data has changed.
             hashedval = hashlib.md5(str(repr(credentials)).encode('utf-8')).hexdigest()
 
-            k8s_auth = _get_k8s_auth(credentials=credentials)
+            try:
+                k8s_auth = _get_k8s_auth(credentials=credentials)
+            except BadEKSToken:
+                app.logger.error("unable to get EKS token for '{}'".format(credentials))
+                continue
+            except ClusterAttributeError:
+                app.logger.error("error with cluster attributes for '{}'".format(credentials))
+                continue
 
             for config in k8s_auth:
                 app.logger.debug({"config": config})


### PR DESCRIPTION
Currently, if secret-updater is attempting to update something on a cluster it cannot authenticate to (either bad auth, cluster removed, etc) it fails fairly spectacularly, and fails to update all the clusters that it can access.

Often times this failure (despite logged) can be missed, so the first experience we have is secrets not getting updated when they should be.

Let's flip that about, lets skip over (but keep logging) those cases.